### PR TITLE
Fix incompatible pointer types (32-bit) + fix for PHP 8.5

### DIFF
--- a/rrd.c
+++ b/rrd.c
@@ -55,7 +55,7 @@ PHP_FUNCTION(rrd_fetch)
 	rrd_args *argv;
 	/* returned values if rrd_fetch doesn't fail */
 	time_t start, end;
-	zend_ulong step,
+	unsigned long step,
 	ds_cnt; /* count of data sources */
 	char **ds_namv; /* list of data source names */
 	rrd_value_t *ds_data; /* all data from all sources */
@@ -396,7 +396,7 @@ PHP_FUNCTION(rrd_xport)
 	/* return values from rrd_xport */
 	int xxsize;
 	time_t start, end, time_index;
-	zend_ulong step, outvar_count;
+	unsigned long step, outvar_count;
 	char **legend_v;
 	rrd_value_t *data, *data_ptr;
 	zval zv_data;

--- a/rrd.c
+++ b/rrd.c
@@ -12,7 +12,11 @@
 #endif
 
 #include "php.h"
+#if PHP_VERSION_ID < 70200
 #include "ext/standard/php_smart_string.h"
+#else
+#include "Zend/zend_smart_string.h"
+#endif
 #include "ext/standard/php_array.h"
 #include "ext/standard/info.h"
 

--- a/rrd_graph.c
+++ b/rrd_graph.c
@@ -14,7 +14,11 @@
 
 #include "php.h"
 #include "zend_exceptions.h"
+#if PHP_VERSION_ID < 70200
 #include "ext/standard/php_smart_string.h"
+#else
+#include "Zend/zend_smart_string.h"
+#endif
 
 #include <rrd.h>
 

--- a/rrd_update.c
+++ b/rrd_update.c
@@ -14,7 +14,11 @@
 
 #include "php.h"
 #include "zend_exceptions.h"
+#if PHP_VERSION_ID < 70200
 #include "ext/standard/php_smart_string.h"
+#else
+#include "Zend/zend_smart_string.h"
+#endif
 
 #include <rrd.h>
 


### PR DESCRIPTION
This is a warning, but a real problem
Become an error on Fedora with with GCC 14

```
/builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c: In function 'zif_rrd_fetch':
/builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c:79:70: error: passing argument 5 of 'rrd_fetch' from incompatible pointer type [-Wincompatible-pointer-types]
   79 |         if (rrd_fetch(argv->count - 1, &argv->args[1], &start, &end, &step, &ds_cnt,
      |                                                                      ^~~~~
      |                                                                      |
      |                                                                      zend_ulong * {aka unsigned int *}
In file included from /builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c:19:
/usr/include/rrd.h:201:5: note: expected 'long unsigned int *' but argument is of type 'zend_ulong *' {aka 'unsigned int *'}
  201 |     unsigned long *,
      |     ^~~~~~~~~~~~~~~
/builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c:79:77: error: passing argument 6 of 'rrd_fetch' from incompatible pointer type [-Wincompatible-pointer-types]
   79 |         if (rrd_fetch(argv->count - 1, &argv->args[1], &start, &end, &step, &ds_cnt,
      |                                                                             ^~~~~~~
      |                                                                             |
      |                                                                             zend_ulong * {aka unsigned int *}
/usr/include/rrd.h:202:5: note: expected 'long unsigned int *' but argument is of type 'zend_ulong *' {aka 'unsigned int *'}
  202 |     unsigned long *,
      |     ^~~~~~~~~~~~~~~
/builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c: In function 'zif_rrd_xport':
/builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c:418:77: error: passing argument 6 of 'rrd_xport' from incompatible pointer type [-Wincompatible-pointer-types]
  418 |         if (rrd_xport(argv->count-1, &argv->args[1], &xxsize, &start, &end, &step,
      |                                                                             ^~~~~
      |                                                                             |
      |                                                                             zend_ulong * {aka unsigned int *}
/usr/include/rrd.h:236:5: note: expected 'long unsigned int *' but argument is of type 'zend_ulong *' {aka 'unsigned int *'}
  236 |     unsigned long *,
      |     ^~~~~~~~~~~~~~~
/builddir/build/BUILD/php-pecl-rrd-2.0.3/NTS/rrd.c:419:17: error: passing argument 7 of 'rrd_xport' from incompatible pointer type [-Wincompatible-pointer-types]
  419 |                 &outvar_count, &legend_v, &data) == -1) {
      |                 ^~~~~~~~~~~~~
      |                 |
      |                 zend_ulong * {aka unsigned int *}
/usr/include/rrd.h:237:5: note: expected 'long unsigned int *' but argument is of type 'zend_ulong *' {aka 'unsigned int *'}
  237 |     unsigned long *,
      |     ^~~~~~~~~~~~~~~

```